### PR TITLE
Handle missing dependency error during `uv add`

### DIFF
--- a/src/hatch_pinned_extra/__init__.py
+++ b/src/hatch_pinned_extra/__init__.py
@@ -59,7 +59,7 @@ def _extract_requirements(
 ) -> list[Requirement]:
     reqs = []
 
-    for version in deps[name]:
+    for version in deps.get(name, {}):
         package = deps[name][version]
 
         req_string = f"{name}=={version}"

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 
 [[package]]


### PR DESCRIPTION
See https://github.com/edgarrmondragon/hatch-pinned-extra/issues/11#issuecomment-2761851890.

Closes #11.