### PR TITLE
Handle missing `uv.lock` and emit a warning

### DIFF
--- a/src/hatch_pinned_extra/__init__.py
+++ b/src/hatch_pinned_extra/__init__.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import os.path
 import sys
+import warnings
 from typing import TYPE_CHECKING
 
 from hatchling.metadata.plugin.interface import MetadataHookInterface
@@ -114,6 +115,16 @@ class PinnedExtraMetadataHook(MetadataHookInterface):
 
     def update(self, metadata: dict) -> None:
         extra_name = self.config.get("extra-name", "pinned")
+
+        uv_lock_path = os.path.join(self.root, "uv.lock")
+        if not os.path.exists(uv_lock_path):
+            warnings.warn(
+                f"uv.lock file not found in {self.root}. "
+                f"Skipping the generation of the '{extra_name}' extra.",
+                UserWarning,
+                stacklevel=2,
+            )
+            return
 
         with open(os.path.join(self.root, "uv.lock"), "rb") as f:
             lock = tomllib.load(f)

--- a/tests/test_uv_lock.py
+++ b/tests/test_uv_lock.py
@@ -22,6 +22,9 @@
 
 import sys
 from copy import deepcopy
+from pathlib import Path
+
+import pytest
 
 if sys.version_info < (3, 11):
     import tomli as tomllib
@@ -29,6 +32,15 @@ else:
     import tomllib
 
 from hatch_pinned_extra import PinnedExtraMetadataHook, parse_pinned_deps_from_uv_lock
+
+
+def test_missing_uv_lock(tmp_path: Path) -> None:
+    hook = PinnedExtraMetadataHook(str(tmp_path), {"extra-name": "pinned"})
+    with pytest.warns(
+        UserWarning,
+        match="uv.lock file not found in",
+    ):
+        hook.update({})
 
 
 def test_parse_pinned_deps_from_uv_lock() -> None:


### PR DESCRIPTION
Closes https://github.com/edgarrmondragon/hatch-pinned-extra/issues/17
